### PR TITLE
Try to ping server before setting it as initial server

### DIFF
--- a/src/main/java/com/actualplayer/rememberme/RememberMe.java
+++ b/src/main/java/com/actualplayer/rememberme/RememberMe.java
@@ -19,6 +19,8 @@ import net.luckperms.api.LuckPermsProvider;
 import org.slf4j.Logger;
 
 import java.nio.file.Path;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
 
 @Plugin(id = "@ID@", name = "@NAME@", version = "@VERSION@", description = "@DESCRIPTION@", authors = {"ActualPlayer"}, dependencies = { @Dependency(id = "luckperms", optional = true) })
 public class RememberMe {
@@ -72,9 +74,12 @@ public class RememberMe {
             handler.getLastServerName(chooseServerEvent.getPlayer().getUniqueId()).thenAcceptAsync(lastServerName -> {
                 if (lastServerName != null) {
                     getServer().getServer(lastServerName).ifPresent((registeredServer) -> {
-                    	registeredServer.ping().thenRun(() -> {
-                    		chooseServerEvent.setInitialServer(registeredServer);
-                    	});
+                    	try {
+                    		registeredServer.ping().join();
+                    	} catch(CancellationException|CompletionException exception) {
+                    		return;
+                    	}
+                    	chooseServerEvent.setInitialServer(registeredServer);
                     });
                 }
             }).join();

--- a/src/main/java/com/actualplayer/rememberme/RememberMe.java
+++ b/src/main/java/com/actualplayer/rememberme/RememberMe.java
@@ -71,7 +71,11 @@ public class RememberMe {
         if (!chooseServerEvent.getPlayer().hasPermission("rememberme.notransfer")) {
             handler.getLastServerName(chooseServerEvent.getPlayer().getUniqueId()).thenAcceptAsync(lastServerName -> {
                 if (lastServerName != null) {
-                    getServer().getServer(lastServerName).ifPresent(chooseServerEvent::setInitialServer);
+                    getServer().getServer(lastServerName).ifPresent((registeredServer) -> {
+                    	registeredServer.ping().thenRun(() -> {
+                    		chooseServerEvent.setInitialServer(registeredServer);
+                    	});
+                    });
                 }
             }).join();
         }

--- a/src/main/java/com/actualplayer/rememberme/handlers/LuckPermsHandler.java
+++ b/src/main/java/com/actualplayer/rememberme/handlers/LuckPermsHandler.java
@@ -12,7 +12,6 @@ import net.luckperms.api.node.NodeType;
 import net.luckperms.api.node.types.MetaNode;
 import net.luckperms.api.query.QueryMode;
 import net.luckperms.api.query.QueryOptions;
-import org.checkerframework.checker.nullness.Opt;
 
 import java.util.Collection;
 import java.util.Optional;


### PR DESCRIPTION
Issue: #3 

Adds a simple ping check before setting the initial server to make sure that players fall back to another server if the previous server went down.