### PR TITLE
Add more permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ RememberMe versions < 1.2 can be used with the currently released version of Vel
 ## Permissions
 
 * `rememberme.notransfer` - doesn't transfer the user on login, but follows the default Velocity 'try' array instead, see velocity.toml
+* `rememberme.notracking` - don't track the user at all (can be used with LuckPerms contexts to ignore tracking on certain servers)
 
 ## Integrations
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ RememberMe versions < 1.2 can be used with the currently released version of Vel
 
 * `rememberme.notransfer` - doesn't transfer the user on login, but follows the default Velocity 'try' array instead, see velocity.toml
 * `rememberme.notracking` - don't track the user at all (can be used with LuckPerms contexts to ignore tracking on certain servers)
+* `rememberme.ignoreforcedhosts` - ignore forced hosts and connect to the last server (otherwise forced hosts have priority)
 
 ## Integrations
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_11
 
 group 'com.actualplayer'
-version '1.3.1'
+version '1.3.2'
 description 'A way for the user to login to the server he last connected to.'
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_11
 
 group 'com.actualplayer'
-version '1.3.0'
+version '1.3.1'
 description 'A way for the user to login to the server he last connected to.'
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_11
 
 group 'com.actualplayer'
-version '1.2.3'
+version '1.3.0'
 description 'A way for the user to login to the server he last connected to.'
 
 repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/actualplayer/rememberme/RememberMe.java
+++ b/src/main/java/com/actualplayer/rememberme/RememberMe.java
@@ -88,6 +88,8 @@ public class RememberMe {
 
     @Subscribe
     public void onServerChange(ServerConnectedEvent serverConnectedEvent) {
-        handler.setLastServerName(serverConnectedEvent.getPlayer().getUniqueId(), serverConnectedEvent.getServer().getServerInfo().getName());
+        if (!serverConnectedEvent.getPlayer().hasPermission("rememberme.notracking")) {
+            handler.setLastServerName(serverConnectedEvent.getPlayer().getUniqueId(), serverConnectedEvent.getServer().getServerInfo().getName());
+        }
     }
 }

--- a/src/main/java/com/actualplayer/rememberme/RememberMe.java
+++ b/src/main/java/com/actualplayer/rememberme/RememberMe.java
@@ -3,10 +3,11 @@ package com.actualplayer.rememberme;
 import com.actualplayer.rememberme.handlers.*;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import com.velocitypowered.api.event.PostOrder;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.LoginEvent;
 import com.velocitypowered.api.event.player.PlayerChooseInitialServerEvent;
-import com.velocitypowered.api.event.player.ServerConnectedEvent;
+import com.velocitypowered.api.event.player.ServerPostConnectEvent;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Dependency;
 import com.velocitypowered.api.plugin.Plugin;
@@ -94,10 +95,11 @@ public class RememberMe {
         }).join();
     }
 
-    @Subscribe
-    public void onServerChange(ServerConnectedEvent serverConnectedEvent) {
+    @Subscribe(order = PostOrder.LAST)
+    public void onServerChange(ServerPostConnectEvent serverConnectedEvent) {
         if (!serverConnectedEvent.getPlayer().hasPermission("rememberme.notracking")) {
-            handler.setLastServerName(serverConnectedEvent.getPlayer().getUniqueId(), serverConnectedEvent.getServer().getServerInfo().getName());
+            var p = serverConnectedEvent.getPlayer();
+            p.getCurrentServer().ifPresent(s -> handler.setLastServerName(p.getUniqueId(), s.getServerInfo().getName()));
         }
     }
 }


### PR DESCRIPTION
this adds a new permission called `rememberme.notracking` which makes it possible to ignore certain servers like lobbys etc.

note: ~this works in theory but in reality there are issues with LuckPerms ignoring contexts immediately after joining a server~ ([LuckPerms issue](https://github.com/lucko/LuckPerms/issues/3133)) _this issue has been fixed_

edit: this also adds a further permission called `rememberme.ignoreforcedhosts` which makes it possible to ignore forced hosts from the velocity config (this means that rememberme now also respects forced hosts by default which it didn't before).